### PR TITLE
docs: add Kafka-4 share-groups & listener scopes

### DIFF
--- a/docs/modules/implementations/pages/stacksaga-kafka-implementation/index.adoc
+++ b/docs/modules/implementations/pages/stacksaga-kafka-implementation/index.adoc
@@ -1,5 +1,5 @@
 :description: Deep-dive technical reference for the StackSaga-Kafka Framework — reactive saga orchestration in Spring Boot microservices using Kafka for asynchronous, event-driven distributed transaction management.
-:keywords: StackSaga-Kafka, saga orchestration, microservices, Java, Spring Boot, Kafka, distributed transactions, event sourcing, reactive programming, transaction management, idempotency, fault tolerance, workflow compensation, Reactor Kafka, LRT
+:keywords: StackSaga-Kafka, saga orchestration, microservices, Java, Spring Boot, Kafka, Kafka 4, KIP-932, share groups, distributed transactions, event sourcing, reactive programming, transaction management, idempotency, fault tolerance, workflow compensation, LRT
 
 = StackSaga-Kafka Framework (Asynchronous)
 
@@ -17,6 +17,8 @@ Each saga execution is fully persisted — every state transition of the `SagaDo
 *Key capabilities:*
 
 * *Asynchronous saga orchestration* — the orchestrator issues commands to worker services via Kafka and advances the saga state only upon receiving the worker's reply, with no blocking thread held during the wait.
+* *Built for Kafka 4 with KIP-932 share groups* — both the orchestrator and the worker can consume either through the classic consumer-group protocol or through the *Kafka 4 share-group protocol (KIP-932)*, a queue-style consumption model whose parallelism is *not capped by the partition count*.
+The protocol is selectable per endpoint and per event manager through the `groupType` attribute, so you can scale saga processing beyond the number of partitions without repartitioning topics.
 * *Forward and backward recovery* — built-in support for compensating transactions: when a saga step fails, the framework invokes `onNextRevert()` on the `SagaEventNavigator` in reverse step order, triggering rollback actions on each previously completed service.
 * *Per-domain reply topology* — outbound command topics are created per worker intent; inbound reply topics are created per saga domain by the framework.
 A system with three saga domains maintains exactly three reply topics, keeping Kafka partition management predictable.
@@ -218,9 +220,9 @@ To run your application as an orchestrator service, first add the `stacksaga-kaf
 </dependencies>
 ----
 
-IMPORTANT: It has been built internally using reactive programming principles, ensuring high scalability and performance.
-It primarily uses *Reactor Kafka* for interacting with Kafka.
-Even though the framework operates reactively under the hood, it fully supports both reactive and non-reactive (imperative) application models.
+IMPORTANT: The framework targets *Kafka 4* and *Spring Boot 4* and integrates directly with Spring for Apache Kafka's listener containers.
+It fully supports the *Kafka 4 share-group protocol (KIP-932)* for queue-style consumption in addition to the classic consumer-group protocol, selectable per event manager and per endpoint via the `groupType` attribute.
+Application code can be written in either a reactive (`Mono`/`Flux`) or a non-reactive (imperative/blocking) style — both are first-class and fully supported.
 
 IMPORTANT: If your orchestrator service should work as the worker for another saga domain owned by a different orchestrator, no need to add the worker dependency (`stacksaga-kafka-worker-starter`) separately. because the orchestrator dependency already includes the worker dependency transitively.
 

--- a/docs/modules/implementations/pages/stacksaga-kafka-implementation/orchestrator/properties.adoc
+++ b/docs/modules/implementations/pages/stacksaga-kafka-implementation/orchestrator/properties.adoc
@@ -1,5 +1,5 @@
-:description: Configuration properties reference for stacksaga-kafka-orchestrator-spring-boot-starter — domain entity scanning, Kafka topic auto-creation, shared response listener processing modes, concurrency, and instance cluster/region/zone settings.
-:keywords: StackSaga-Kafka, configuration properties, stacksaga-kafka-orchestrator, domain-entity-scan, auto-create, shared response listener, processing mode, concurrency, instance cluster, region, zone
+:description: Configuration properties reference for stacksaga-kafka-orchestrator-spring-boot-starter — domain entity scanning, the global callback listener group protocol (consumer group or Kafka 4 share group) and concurrency, and instance cluster/region/zone settings.
+:keywords: StackSaga-Kafka, configuration properties, stacksaga-kafka-orchestrator, domain-entity-scan, global-callback-listener, group-type, share group, KIP-932, concurrency, instance cluster, region, zone
 
 [[configuration_properties_for_stacksaga_kafka_orchestrator]]
 = Configuration Properties Of `stacksaga-kafka-orchestrator-spring-boot-starter`
@@ -17,20 +17,15 @@
 | `[]`
 | A comma-separated list of package names to scan for `@SagaDomainEntity` annotated classes. for instance, `com.example.domain,com.example.anotherdomain`.
 
-| `stacksaga.kafka.orchestrator.auto-create`
-| `boolean`
-| `true`
-| A flag to enable or disable automatic creation of Kafka topics when the application starts.
+| `stacksaga.kafka.orchestrator.global-callback-listener.group-type`
+| `GroupType`
+| `SHARE`
+| The Kafka group protocol used by the global callback listener container that consumes the callback topics of all `SHARED_GLOBAL` event managers. `SHARE` uses the Kafka 4 share-group protocol (KIP-932, queue-style consumption); `CONSUMER` uses the classic consumer-group protocol. xref:stacksaga-kafka-implementation/orchestrator/topics-event-manager.adoc#topic_model_stacksaga_kafka_orchestrator[See more] about the listener models.
 
-| `stacksaga.kafka.orchestrator.shared-response-listener.processing-mode`
-| `SharedListenerProcessingMode`
-| PARTITION_ORDERED`
-| The processing mode for the shared response listener.  xref:stacksaga-kafka-implementation/orchestrator/topics-event-manager.adoc#isolated_listener_models_for_orchestrator[see more] for more details about the processing modes.
-
-| `stacksaga.kafka.orchestrator.shared-response-listener.concurrency`
+| `stacksaga.kafka.orchestrator.global-callback-listener.concurrency`
 | `int`
-| `128`
-| if the `shared-response-listener.processing-mode` is set to `CONCURRENT`, this property defines the level of concurrency for processing messages in the shared response listener. it is ignored for other processing modes.
+| `20`
+| The concurrency level of the global callback listener container. With `group-type: SHARE`, this can be set to any desired value because share groups are not limited by the partition count. With `group-type: CONSUMER`, it should not exceed the total number of partitions of the callback topics bound to the global container.
 
 |`stacksaga.instance.cluster`
 |`String`

--- a/docs/modules/implementations/pages/stacksaga-kafka-implementation/orchestrator/topics-event-manager.adoc
+++ b/docs/modules/implementations/pages/stacksaga-kafka-implementation/orchestrator/topics-event-manager.adoc
@@ -1,5 +1,5 @@
 :description: StackSaga Kafka Topics and EventManager specifications — defining topics, naming rules, topic keys, EventManager routing with onNext/onNextRevert, and reply topic listener models.
-:keywords: StackSaga, AbstractTopic, EventManager, onNext, onNextRevert, topic name, topic key, ListenerScope, SHARED, ISOLATED
+:keywords: StackSaga, AbstractTopic, EventManager, onNext, onNextRevert, topic name, topic key, OrchestratorListenerScope, SHARED_GLOBAL, SHARED_GROUP, ISOLATED, groupType, share group, KIP-932, Kafka 4
 = Topics and EventManager
 
 [[custom_topic_implementation]]
@@ -137,7 +137,8 @@ So the EventManager is the component that is responsible for that. let's create 
 //<2>
 @SagaEventManager(
         value = "placeOrderEventManager", //<3>
-        listenerScope = ListenerScope.SHARED, //<4>
+        listenerScope = OrchestratorListenerScope.SHARED_GLOBAL, //<4>
+        groupType = GroupType.SHARE,
         domainRootTopicSuffix = "place-order" //<5>
 )
 public class PlaceOrderEventManager extends AbstractEventManager<OrderDomainEntity, PlaceOrderTopic> { //<1>
@@ -217,7 +218,10 @@ public class PlaceOrderEventManager extends AbstractEventManager<OrderDomainEnti
 <3> *value*: provide the name of the spring bean for the custom EventManager. it is used for identification of the EventManager by the name.
 
 
-<4> *listenerScope*: Provide the listener scope for the EventManager. it can be either `ListenerScope.SHARED` or `ListenerScope.ISOLATED`. see xref:#topic_model_stacksaga_kafka_orchestrator[] for more details.
+<4> *listenerScope* and *groupType*: Configure how this event manager's callback (reply) topic is consumed. +
+*`listenerScope`* selects the container allocation — `OrchestratorListenerScope.SHARED_GLOBAL` (pool into the single global container, the default choice), `OrchestratorListenerScope.SHARED_GROUP` (share a named container with other managers), or `OrchestratorListenerScope.ISOLATED` (a dedicated container). +
+*`groupType`* selects the Kafka group protocol — `GroupType.CONSUMER` (classic consumer group) or `GroupType.SHARE` (Kafka 4 share group / KIP-932, queue-style consumption not capped by partition count). +
+See xref:#topic_model_stacksaga_kafka_orchestrator[] for full details.
 
 <5> *domainRootTopicSuffix*: provide the common suffix for the topics that are related to the same domain. this is used for creating the domain-root-topic (topic for receiving the response messages from the kafka clint endpoints) internally by the framework.
 
@@ -226,7 +230,7 @@ public class PlaceOrderEventManager extends AbstractEventManager<OrderDomainEnti
 <7> Override the `onNext()` method to determine the next topic based on the recently completed topic and the current state of the domain entity.
 This method is invoked by the framework after each successful execution in the primary flow and its primary responsibility is *routing* — deciding which topic to trigger next.
 Lightweight orchestrator-side bookkeeping is also permitted here: for example, recording a navigation timestamp in the domain entity metadata (as shown above) is a safe, low-cost operation that will be included in the persisted domain entity snapshot for traceability.
-However, business logic, database calls, external HTTP requests, or any other I/O must not be placed here, as this method runs on the reactor event-loop thread.
+However, business logic, database calls, external HTTP requests, or any other blocking I/O must not be placed here, because this method runs on the callback listener container's processing threads (a bounded pool sized by the container's concurrency); blocking them reduces callback throughput and can stall other sagas that share the container.
 Return `SagaPrimaryEventAction.next(topic)` to advance to the next step, or `SagaPrimaryEventAction.complete()` when all steps have been processed successfully.
 
 <8> Override the `onNextRevert()` (Optional) method to perform any action at each step of the compensation flow.
@@ -243,10 +247,10 @@ See the Javadoc of the class for full details about all parameters.
 <10> Sample usage of the `remainingReverts` and the `recentExecutedTopic` parameters in the `onNextRevert()` method.
 Use `recentExecutedTopic` to identify which compensation step just completed, and `remainingReverts` to inspect the full set of compensation steps still pending.
 
-WARNING: As a best practice, avoid performing any I/O-intensive or High CPU-intensive operations inside the event navigator.
-This method should be used only to evaluate conditions based on the provided parameters. +
-The reason is that the Stacksaga-engine internally relies on Project Reactor's reactive pipelines, which run on non-blocking event-loop threads.
-Executing expensive operations here could block those threads, leading to performance bottlenecks and impacting the entire application.
+WARNING: As a best practice, avoid performing any I/O-intensive or high-CPU operations inside the event navigator.
+These methods should be used only to evaluate routing conditions based on the provided parameters. +
+`onNext()` and `onNextRevert()` execute on the callback listener container's processing threads — a limited pool shared by the sagas bound to that container.
+Executing expensive operations here occupies those threads, leading to head-of-line blocking, reduced callback throughput, and degraded performance across the application.
 
 .Quick Reference: Exception Behavior in `onNext()` and `onNextRevert()`
 [cols="2,2,2",options="header"]
@@ -286,79 +290,89 @@ the `domainRootTopicSuffix` is configured in the `@SagaEventManager` annotation 
 )
 ----
 
-*Listener Models*
+*Listener Container Scopes*
 
-Even though it creates dedicated topic for each `EventManager`, there are two different listener models that are used to consume the messages from those topics based on the `listenerScope` configuration of the `EventManager` which is mentioned in the `@SagaEventManager` annotation. those two listener models are,
+Even though a dedicated reply topic is created for each `EventManager`, the container that *consumes* those reply topics is allocated according to the `listenerScope` configured in the `@SagaEventManager` annotation. There are three scopes:
 
-. xref:#shared_listener_models_for_orchestrator[]
+. xref:#shared_global_listener_models_for_orchestrator[]
+. xref:#shared_group_listener_models_for_orchestrator[]
 . xref:#isolated_listener_models_for_orchestrator[]
 
-Let's dive into details of each listener model.
+Independently of the scope, each container consumes using the Kafka group protocol chosen with the `groupType` attribute — `GroupType.CONSUMER` (classic consumer group, backed by a `ConcurrentMessageListenerContainer`) or `GroupType.SHARE` (Kafka 4 share group / KIP-932, queue-style consumption backed by a `ShareKafkaMessageListenerContainer`, whose parallelism is not capped by the partition count).
 
-[[shared_listener_models_for_orchestrator]]
-=== SHARED
+IMPORTANT: A single container speaks only one protocol, so every event manager that shares a container — all `SHARED_GLOBAL` managers, or all members of a given `SHARED_GROUP` — must declare the *same* `groupType`. A mismatch fails fast at startup. `GroupType.SHARE` requires a Kafka 4.x broker with share groups enabled.
 
-If the `@SagaEventManager` is configured with `listenerScope = ListenerScope.SHARED`, the framework bind the relevant response-topic of that EventManager to a shared-listener. +
-If you have multiple EventManagers with `listenerScope = ListenerScope.SHARED` all the topics that are related to those EventManagers will be bind to the same shared-listener.
+Let's dive into details of each listener scope.
+
+[[shared_global_listener_models_for_orchestrator]]
+=== SHARED_GLOBAL
+
+If the `@SagaEventManager` is configured with `listenerScope = OrchestratorListenerScope.SHARED_GLOBAL`, the framework binds that event manager's reply topic to a single, global callback listener container shared by *all* `SHARED_GLOBAL` event managers.
+This is the default and the right choice for most sagas: it pools every callback topic into one container instead of spinning up a container per orchestrator, keeping consumer-thread usage low.
 
 Here is the architecture for the shared listener model in `stacksaga-kafka-orchestrator`.
 
-image::implementations:stacksaga-kafka/stacksaga-kafka-engine-shared-kafka-receiver-in-stacksaga-kafka-orchestrator.svg[Shared kafka receiver in stacksaga kafka orchestrator,width=800]
+image::implementations:stacksaga-kafka/stacksaga-kafka-engine-shared-kafka-receiver-in-stacksaga-kafka-orchestrator.svg[Shared listener container in stacksaga kafka orchestrator,width=800]
 
+* The *group protocol* and *concurrency* of the global container are configured application-wide via `stacksaga.kafka.orchestrator.global-callback-listener.group-type` and `stacksaga.kafka.orchestrator.global-callback-listener.concurrency` (see xref:stacksaga-kafka-implementation/orchestrator/properties.adoc#configuration_properties_for_stacksaga_kafka_orchestrator[]). The default group protocol is `SHARE`.
+* The consumer group follows the convention `saga-os-{serviceName}-…` where `os` stands for *Orchestration Service*.
+* The listener is configured with `auto.offset.reset=earliest`, so previously published messages can be consumed after a service restart when no committed offset is available.
+* Message consumption uses *At-Least-Once* delivery semantics; each message is acknowledged only after it has been processed successfully. If a failure occurs after processing but before the acknowledgement/offset is durably recorded, the message may be redelivered and reprocessed — the framework's idempotency check discards genuine duplicates.
 
-* The consumer group is configured using the following naming convention: `{serviceName}-os` where `os` stands for *Orchestration Service*. +
-For example, if the service name is `order-service`, the consumer group for the shared root topic will be: `order-service-os`
+[[shared_group_listener_models_for_orchestrator]]
+=== SHARED_GROUP
 
-* The shared listener/receiver is configured with: `auto.offset.reset=earliest` This ensures that previously published messages can be consumed after a service restart when no committed offset is available.
+If the `@SagaEventManager` is configured with `listenerScope = OrchestratorListenerScope.SHARED_GROUP`, its reply topic is consumed by a container shared only with *other* event managers that declare the same listener container name.
+This pools a specific subset of event managers into their own container, separate from the global one, when they benefit from dedicated concurrency or should be isolated from the load of unrelated managers.
 
-* Message consumption is configured using *At-Least-Once* delivery semantics to ensure that messages are not lost, even in the event of service downtime or unexpected failures.
+The container is configured through the `sharedGroupExecutionListener` attribute of `@SagaEventManager`:
 
-* To guarantee *At-Least-Once* delivery semantics, each message is acknowledged only after it has been successfully processed.
+[source,java]
+----
+@SagaEventManager(
+        value = "placeOrderEventManager",
+        domainRootTopicSuffix = "place-order",
+        listenerScope = OrchestratorListenerScope.SHARED_GROUP,
+        groupType = GroupType.SHARE,
+        sharedGroupExecutionListener = @SagaEventManagerListener(
+                listenerContainerName = "order-group", // required: the group key other managers repeat to join
+                concurrency = 10,
+                autoStart = true
+        )
+)
+----
 
-* Acknowledged offsets are committed periodically using the framework's default time-based commit configuration.
-Therefore, if a failure occurs after a message has been processed and acknowledged but before the offset has been committed, the message may be delivered again and reprocessed after recovery.
-
-* *Processing mode*:
-The shared listener can be configured via `stacksaga.kafka.orchestrator.shared-response-listener.processing-mode` property which determines how messages are processed.
-it can be configured for either `SharedListenerProcessingMode.CONCURRENT` or `SharedListenerProcessingMode.PARTITION_ORDERED`. +
-In `CONCURRENT` mode, messages are processed concurrently without preserving the order of messages from the same partition. +
-In `PARTITION_ORDERED` mode, messages are processed sequentially per partition while allowing concurrent execution across multiple partitions. +
-The default processing mode for the shared listener is `PARTITION_ORDERED` to ensure a balance between throughput and consistency while preserving the order of messages within each partition.
-See more relevant xref:stacksaga-kafka-implementation/orchestrator/orchestrator-usage.adoc#configuration_properties_for_stacksaga_kafka_orchestrator[]
+* `listenerContainerName` is *required* here — it is the group key that other event managers repeat to share this container. Registration fails if it is left blank.
+* All members must declare the *same* `groupType`.
+* The container's concurrency is the *maximum* concurrency declared across all members of the group, and it auto-starts if *any* member requests auto-start.
 
 [[isolated_listener_models_for_orchestrator]]
 === ISOLATED
 
-If the `@SagaEventManager` is configured with `listenerScope = ListenerScope.ISOLATED`, the framework will create a dedicated listener for the relevant response-topic of that EventManager. therefore, if you have multiple EventManagers with `listenerScope = ListenerScope.ISOLATED`, each EventManager will have its own dedicated listener and its own dedicated topic to receive the response messages from the kafka worker endpoints. this approach provides better isolation and can help to avoid any potential interference between different EventManagers, but it can also increase the resource consumption due to having multiple listeners.
+If the `@SagaEventManager` is configured with `listenerScope = OrchestratorListenerScope.ISOLATED`, the framework creates a dedicated callback listener container for that event manager's reply topic, consumed by no other manager.
+Use it for orchestrators with distinct performance or reliability requirements — e.g. a high-throughput or latency-sensitive saga — where sharing a container could cause head-of-line blocking or contention over consumer threads. It provides the best isolation at the cost of higher resource usage.
 
 Here is the architecture for the isolated-listener model in `stacksaga-kafka-orchestrator`.
 
-image::implementations:stacksaga-kafka/stacksaga-kafka-engine-isolated-kafka-receiver-in-stacksaga-kafka-orchestrator.svg[Isolated kafka receiver in stacksaga kafka orchestrator,width=800]
+image::implementations:stacksaga-kafka/stacksaga-kafka-engine-isolated-kafka-receiver-in-stacksaga-kafka-orchestrator.svg[Isolated listener container in stacksaga kafka orchestrator,width=800]
 
+The dedicated container is configured through the `isolatedExecutionListener` attribute of `@SagaEventManager`:
 
-* The name of the domain-root topic is created by concatenating the provided `domainRootTopicSuffix` with the prefix `saga.internal.isolated.{serviceName}.{domainRootTopicSuffix}` For instance, if the service name is `order-service` and the `domainRootTopicSuffix` is `place-order`, the domain-root topic name will be `saga.internal.isolated.order-service.place-order`.
+[source,java]
+----
+@SagaEventManager(
+        value = "placeOrderEventManager",
+        domainRootTopicSuffix = "place-order",
+        listenerScope = OrchestratorListenerScope.ISOLATED,
+        groupType = GroupType.SHARE,
+        isolatedExecutionListener = @SagaEventManagerListener(
+                listenerContainerName = "", // optional: defaults to {beanName}ListenerContainer
+                concurrency = 5,
+                autoStart = true
+        )
+)
+----
 
-* the consumer group for the domain-root topic is set as the same way as the shared root topic by following the convention `{serviceName}-os`. therefore, in the previous example, the consumer group for the domain-root topic will be `order-service-os`. the other configurations for the domain-root topic are the same as the shared root topic.
-+
-NOTE: The consumer group name is intentionally kept identical to the shared listener (`{serviceName}-os`) so that switching an `EventManager` from `ListenerScope.SHARED` to `ListenerScope.ISOLATED` (or back) at any time does not reset offset tracking.
-Without this, changing the listener scope would cause the new consumer group to start from `earliest`, potentially re-processing a large backlog of already-completed reply messages.
-
-* Same as the shared, the domain-root topics are also configured with `auto.offset.reset=earliest` to ensure that previously published messages can be consumed after a service restart when no committed offset is available.
-
-* Same as the shared root topic, the domain-root topics are also configured with *At-Least-Once* delivery semantics, and the offsets are acknowledged and committed in the same way as the shared root topic.
-
-* Same as the shared root topic, each message is acknowledged only after it has been successfully processed, and if a failure occurs after a message has been processed and acknowledged but before the offset has been committed, the message may be delivered again and reprocessed after recovery.
-
-* Same as the shared root topic, Acknowledged offsets are committed periodically using the framework's default time-based commit configuration.
-Therefore, if a failure occurs after a message has been processed and acknowledged but before the offset has been committed, the message may be delivered again and reprocessed after recovery.
-
-* *Processing mode:* The isolated listener can be configured via the `@SagaEventManager(processingMode=?)` of each EventManager of the domain by providing the `processingMode` parameter which determines how messages are processed in the isolated listener. it can be configured for either for fallowing processing modes,
-** `IsolatedListenerProcessingMode.CONCURRENT`: In this mode, messages are processed concurrently without preserving the order of messages from the same partition.
-
-NOTE: If the isolated listener is configured with `CONCURRENT` processing mode, the concurrency can be customized via `@SagaEventManager(isolatedListenerConcurrency=?)`. read the class Javadoc for more details.
-
-** `IsolatedListenerProcessingMode.PARTITION_ORDERED`: In this mode, messages are processed sequentially per partition while allowing concurrent execution across multiple partitions. +
-The default processing mode for the isolated listener is `PARTITION_ORDERED` to ensure a balance between throughput and consistency while preserving the order of messages within each partition.
-
-** `IsolatedListenerProcessingMode.SEQUENTIAL`: In this mode, messages are processed sequentially without any concurrency. this mode is used when the order of processing is critical and must be preserved across all partitions. +
-The `SEQUENTIAL` processing mode is not recommended for high-throughput scenarios due to its sequential nature, which can become a bottleneck. it is recommended to use this mode only when the strict ordering of message processing is a hard requirement and the expected message volume is low to moderate.
+* `listenerContainerName` is optional; if left blank, the container is named `{beanName}ListenerContainer`, where `{beanName}` is the event manager's `value`.
+* `concurrency` and `autoStart` come from this `@SagaEventManagerListener`.
+* The consumer group follows the same `saga-os-{serviceName}-…` convention, and the same `auto.offset.reset=earliest` and At-Least-Once semantics as SHARED_GLOBAL.

--- a/docs/modules/implementations/pages/stacksaga-kafka-implementation/stacksaga-kafka-architecture.adoc
+++ b/docs/modules/implementations/pages/stacksaga-kafka-implementation/stacksaga-kafka-architecture.adoc
@@ -108,6 +108,8 @@ All replies — regardless of which worker sent them — flow back to the single
 The reply topic consumer is configured with `auto.offset.reset=earliest` and at-least-once delivery semantics.
 This is safe because the framework's built-in idempotency check (via the per-span idempotency key) detects any duplicate re-delivery that may occur after a consumer rebalance or an offset commit delay, and discards the duplicate without re-executing the saga step.
 
+NOTE: The reply topics (on the orchestrator) and the command topics (on the workers) are consumed through Spring for Apache Kafka listener containers. Each container can use either the classic Kafka *consumer-group* protocol or the *Kafka 4 share-group* protocol (KIP-932) — a queue-style model whose parallelism is not capped by the partition count — selectable per event manager and per endpoint via the `groupType` attribute. See xref:stacksaga-kafka-implementation/orchestrator/topics-event-manager.adoc#topic_model_stacksaga_kafka_orchestrator[the orchestrator listener models] and xref:stacksaga-kafka-implementation/worker/worker-configuration.adoc#topic_model_stacksaga_kafka_worker[the worker listener models].
+
 [[stacksaga-kafka-architecture-2nd-stage]]
 == Stage 2 — Retry-Ready Setup
 

--- a/docs/modules/implementations/pages/stacksaga-kafka-implementation/worker/worker-configuration.adoc
+++ b/docs/modules/implementations/pages/stacksaga-kafka-implementation/worker/worker-configuration.adoc
@@ -1,5 +1,5 @@
-:description: stacksaga-kafka-worker listener models (SHARED and ISOLATED) and configuration properties reference.
-:keywords: stacksaga-kafka-worker, ListenerScope, SHARED, ISOLATED, configuration properties, processing mode, concurrency, retry
+:description: stacksaga-kafka-worker listener-container scopes (SHARED_GLOBAL, SHARED_GROUP, ISOLATED), Kafka group protocols (CONSUMER and Kafka 4 share groups / KIP-932), and configuration properties reference.
+:keywords: stacksaga-kafka-worker, WorkerListenerScope, SHARED_GLOBAL, SHARED_GROUP, ISOLATED, groupType, share group, KIP-932, Kafka 4, concurrency, configuration properties, retry
 
 = Endpoint Listener Models and Configuration
 
@@ -8,82 +8,81 @@
 == Endpoint Topic Listener Models
 
 * *Endpoint Topics* +
-The topics that are used to send the command messages to the worker services are called as `Endpoint Topics`.
-these are the topics that you register in the `EventManager` by overriding the `registerTopics()` method in `stacksaga-kafka-orchestrator` and also the topics that are registered via the `KafkaEndpoint` annotation in the `stacksaga-kafka-worker`. these If the topics are not exist in the Kafka cluster and auto-creation of topics is enabled framework will create the topics automatically during the application startup.
-otherwise, you need to create the topics manually in the Kafka cluster before starting the application.
-The special thing is that both `stacksaga-kafka-orchestrator` and `stacksaga-kafka-worker` try to create the topics if they are not exist in the Kafka cluster and auto-creation of topics is enabled to avoid the delay of `metadata polling` that is caused by the first time topic creation.
-the reason for both trying to create the topics is the `stacksaga-kafka-orchestrator` has the awareness of all the configured topics via the `EventManager` and also the `stacksaga-kafka-worker` has the awareness of the topics that are relevant to their service via the `SagaEndpoint`s.
+The topics that are used to send the command messages to the worker services are called `Endpoint Topics`.
+These are the topics that you register in the `EventManager` by overriding the `registerTopics()` method in `stacksaga-kafka-orchestrator`, and the same topics that are registered via the `@SagaEndpoint` annotation in the `stacksaga-kafka-worker`.
++
+The endpoint topics must exist in the Kafka cluster before they are consumed.
+StackSaga does not create endpoint topics programmatically; their creation depends on the *broker's* topic-management behavior.
+If the broker is configured to auto-create topics (`auto.create.topics.enable=true`), a topic is created on first use with the broker's default partition and replication settings.
+For production it is recommended to pre-create the topics explicitly so that partitions and replication factors are managed deliberately, rather than relying on broker auto-creation.
 
-Even though there are separate topics in kafka, the framework provides two different listener models for consuming messages from the topics in the worker application based on the `listenerScope` configuration in the `@SagaEndpoint` annotation.
-The fallowing are the two listener models for consuming messages from the topics in the worker application.
+The framework provides three listener-container *scopes* for consuming messages from the endpoint topics in the worker application, selected per endpoint via the `listenerScope` attribute of the `@SagaEndpoint` annotation:
 
-. xref:#shared_listener_scope_endpoint_topics[]
+. xref:#shared_global_listener_scope_endpoint_topics[]
+. xref:#shared_group_listener_scope_endpoint_topics[]
 . xref:#isolated_listener_scope_endpoint_topics[]
 
-Let's dive into the details of each listener model.
+Independently of the scope, each container consumes using one of two Kafka group protocols, selected per endpoint via the `groupType` attribute — see xref:#worker_group_type[].
 
-[[shared_listener_scope_endpoint_topics]]
-=== SHARED
+[[worker_group_type]]
+=== Group Protocol (`groupType`)
 
-* If the `@SagaEndpoint` is configured with `listenerScope=ListenerScope.SHARED`, the framework binds the relevant topic(s) to the shared receiver to consume messages for the respective endpoint.
-all the endpoints that are configured with `listenerScope=ListenerScope.SHARED` are bind into this shared `KafkaReceiver`.
+Every listener container speaks exactly one Kafka group protocol, chosen with the `groupType` attribute of `@SagaEndpoint`:
 
-Here is the architecture of the shared listener model for the endpoint topics in stacksaga-kafka-worker application.
+* `GroupType.CONSUMER` — the classic Kafka *consumer-group* protocol, backed by a Spring `ConcurrentMessageListenerContainer`.
+Effective parallelism is capped by the number of partitions of the consumed topics (a partition is processed by at most one consumer in the group).
 
-image::implementations:stacksaga-kafka/stacksaga-kafka-engine-shared-kafka-receiver-in-stacksaga-kafka-worker .svg[Shared kafka receiver in stacksaga kafka worker,width=800]
+* `GroupType.SHARE` — the *Kafka 4 share-group* protocol (KIP-932), backed by a `ShareKafkaMessageListenerContainer`.
+Records are distributed cooperatively at the broker in a queue style, so consumer parallelism is *no longer capped by the partition count* — you can raise `concurrency` beyond the number of partitions to scale processing.
+`GroupType.SHARE` requires a Kafka 4.x broker with share groups enabled.
 
-* The *consumer group* is configured using the following naming convention: `{serviceName}-ws` where `ws` stands for worker service.
-for instance, if the service name is `payment-service`, the consumer group name will be `payment-service-ws`.
+IMPORTANT: A single container speaks only one protocol. Therefore every endpoint that shares a container — all `SHARED_GLOBAL` endpoints, or all members of a given `SHARED_GROUP` (`containerId`) — must declare the *same* `groupType`. A mismatch fails fast at application startup.
 
-* The shared listener/receiver is configured with: `auto.offset.reset=earliest` This ensures that previously published messages can be consumed after a service restart when no committed offset is available.
-* Message consumption is configured using *At-Least-Once* delivery semantics to ensure that messages are not lost, even in the event of service downtime or unexpected failures.
-* To guarantee *At-Least-Once* delivery semantics, each message is acknowledged only after it has been successfully processed.
-* Acknowledged offsets are committed periodically using the framework's default time-based commit configuration.
-Therefore, if a failure occurs after a message has been processed and acknowledged but before the offset has been committed, the message may be delivered again and reprocessed after recovery.
-* *Processing mode:* The shared listener can be configured via `stacksaga.kafka.worker.shared-topic-listener.processing-mode` property to control the processing mode for the messages consumed by the shared listener. it can be either `SharedListenerProcessingMode.CONCURRENT` or `SharedListenerProcessingMode.PARTITION_ORDERED`.
-the default processing mode for the shared listener is `SharedListenerProcessingMode.PARTITION_ORDERED` to ensure that messages from the same partition of the same topic are processed in order.
-in `SharedListenerProcessingMode.CONCURRENT` mode, messages are processed concurrently without preserving the order of messages from the same partition.
-And +
-In `SharedListenerProcessingMode.PARTITION_ORDERED` mode, messages from the same partition of the same topic are processed sequentially to preserve the order, while messages from different partitions can be processed concurrently.
-The default processing mode for the shared listener is `SharedListenerProcessingMode.PARTITION_ORDERED` to ensure that messages from the same partition of the same topic are processed in order, which is important for maintaining data consistency and integrity in many use cases.
-however, you can change it to `SharedListenerProcessingMode.CONCURRENT` if your use case allows for concurrent processing without strict ordering requirements, which can improve throughput and performance.
-See more relevant xref:#configuration_properties_stacksaga_kafka_worker[]
+Let's dive into the details of each listener scope.
+
+[[shared_global_listener_scope_endpoint_topics]]
+=== SHARED_GLOBAL
+
+If the `@SagaEndpoint` is configured with `listenerScope = WorkerListenerScope.SHARED_GLOBAL`, the framework binds the endpoint's topic(s) to a single, global listener container that is shared by *all* endpoints declaring `SHARED_GLOBAL`.
+This is the default and the right choice for most endpoints: it keeps consumer-thread usage low by pooling every endpoint into one container instead of spinning up a container per endpoint.
+
+Here is the architecture of the shared listener model for the endpoint topics in a stacksaga-kafka-worker application.
+
+image::implementations:stacksaga-kafka/stacksaga-kafka-engine-shared-kafka-receiver-in-stacksaga-kafka-worker .svg[Shared listener container in stacksaga kafka worker,width=800]
+
+* The *group protocol* and *concurrency* of the global container are configured application-wide through the `stacksaga.kafka.worker.global-endpoint-topic-listener.group-type` and `stacksaga.kafka.worker.global-endpoint-topic-listener.concurrency` properties (see xref:#configuration_properties_stacksaga_kafka_worker[]). The default group protocol is `SHARE`.
+* The global container uses a single shared consumer group derived from the service name (of the form `saga-ws-{serviceName}-…`) where `ws` stands for *worker service*.
+* The listener is configured with `auto.offset.reset=earliest`, so previously published messages can still be consumed after a service restart when no committed offset is available.
+* Message consumption uses *At-Least-Once* delivery semantics, so messages are not lost even during service downtime or unexpected failures.
+* To guarantee At-Least-Once delivery, each message is acknowledged only after it has been successfully processed. With `GroupType.SHARE`, acknowledgement is handled per record at the broker (implicit share acknowledgement); with `GroupType.CONSUMER`, acknowledged offsets are committed periodically. In either case, if a failure occurs after a message has been processed but before its acknowledgement/offset is durably recorded, the message may be delivered again and reprocessed after recovery — the framework's idempotency check discards genuine duplicates.
+
+[[shared_group_listener_scope_endpoint_topics]]
+=== SHARED_GROUP
+
+If the `@SagaEndpoint` is configured with `listenerScope = WorkerListenerScope.SHARED_GROUP`, the endpoint is pooled into a container shared only with *other* endpoints that declare the same `containerId`.
+This lets you isolate a specific subset of endpoints into their own container, separate from the global one, typically because they benefit from dedicated concurrency or should be shielded from the load of unrelated endpoints.
+For example, tagging both `UserValidateEndpoint` and `InventoryCheckEndpoint` with `containerId = "validation-group"` places them in the same dedicated container.
+
+* `containerId` is *required* for this scope — it is the group key that other endpoints repeat to join the same container.
+* All endpoints in the group must declare the *same* `groupType` (validated at startup).
+* The container's concurrency is the *maximum* `concurrency` declared across all endpoints in the group, so raising the concurrency of one member raises it for the whole group.
+* Offset/acknowledgement, delivery semantics, and `auto.offset.reset=earliest` behave the same as xref:#shared_global_listener_scope_endpoint_topics[SHARED_GLOBAL].
 
 [[isolated_listener_scope_endpoint_topics]]
 === ISOLATED
 
-If the `@SagaEndpoint` is configured with `listenerScope=ListenerScope.ISOLATED`, the framework creates a dedicated `KafkaReceiver` for the respective topic(s) to consume messages for that endpoint.
-this approach allows for better isolation and control over the message consumption and processing for that specific endpoint without affecting other endpoints that share the same listener.
-but it can increase the resource consumption as well.
+If the `@SagaEndpoint` is configured with `listenerScope = WorkerListenerScope.ISOLATED`, the framework creates a dedicated listener container for that endpoint's topic(s), consumed by no other endpoint.
+This gives the best isolation and control over consumption and processing for that specific endpoint — useful for high-throughput or latency-sensitive topics where sharing a container could cause head-of-line blocking or contention over consumer threads — at the cost of higher resource usage.
 
-Here is the architecture of the isolated listener model for the endpoint topics in stacksaga-kafka-worker application.
+Here is the architecture of the isolated listener model for the endpoint topics in a stacksaga-kafka-worker application.
 
-image::implementations:stacksaga-kafka/stacksaga-kafka-engine-isolated-kafka-receiver-in-stacksaga-kafka-worker.svg[Isolated kafka receiver in stacksaga kafka worker,width=800]
+image::implementations:stacksaga-kafka/stacksaga-kafka-engine-isolated-kafka-receiver-in-stacksaga-kafka-worker.svg[Isolated listener container in stacksaga kafka worker,width=800]
 
-* The *consumer group* is configured using the following naming convention: `{serviceName}-ws` where `ws` stands for worker service. for instance, if the service name is `payment-service`, the consumer group name will be `payment-service-ws`.
-* Each isolated listener is configured with: `auto.offset.reset=earliest` This ensures that previously published messages can be consumed after a service restart when no committed offset is available.
-* Message consumption is configured using *At-Least-Once* delivery semantics to ensure that messages are not lost, even in the event of service downtime or unexpected failures.
+* The dedicated container is named `{beanName}ListenerContainer`, where `{beanName}` is the endpoint's bean name.
+* Its `groupType` and `concurrency` come from the endpoint's own `@SagaEndpoint` attributes.
+* Offset/acknowledgement, delivery semantics, and `auto.offset.reset=earliest` behave the same as xref:#shared_global_listener_scope_endpoint_topics[SHARED_GLOBAL].
 
-* To guarantee *At-Least-Once* delivery semantics, each message is acknowledged only after it has been successfully processed.
-* Acknowledged offsets are committed periodically using the framework's default time-based commit configuration.
-Therefore, if a failure occurs after a message has been processed and acknowledged but before the offset has been committed, the message may be delivered again and reprocessed after recovery.
-
-** *Scheduler Config For Non-Reactive Endpoint*: If the endpoint is *non-reactive* one, it can be provided a separate `Scheduler` for the primary execution and compensation execution by using the `primaryExecutionSchedulerProvider` and `revertExecutionSchedulerProvider` attributes in the `@SagaEndpoint` annotation.
-by default a shared two `Schedulers` are provided for all the endpoints in the application via `AbstractDefaultPrimaryExecutionSchedulerProvider` and `AbstractDefaultRevertExecutionSchedulerProvider` which are configured to use bounded elastic schedulers that are suitable for blocking workloads.
-but you can provide your own implementation of the `AbstractSagaEndpointSchedulerProvider` to primary and compensation separately for better isolation and control over the thread management for each execution type of each endpoint. see xref:stacksaga-kafka-implementation/worker/worker-endpoints.adoc#configure_custom_scheduler_for_non_reactive_endpoints[] for the implementation.
-
-* *Processing mode:* The isolated listener can be configured via `processingMode` attribute in the `@SagaEndpoint` annotation which determines how messages are processed in the isolated listener. it can be configured for either fallowing modes,
-
-** `IsolatedListenerProcessingMode.CONCURRENT` mode, messages are processed concurrently without preserving the order of messages from the same partition.
-+
-NOTE: If the processing mode `IsolatedListenerProcessingMode.CONCURRENT`, the concurrency can be customized by using the `primaryExecutionConcurrency` and `revertExecutionConcurrency` attributes in the `@SagaEndpoint` annotation.
-it allows to control the number of concurrent threads for processing primary and compensation executions respectively.
-
-** `IsolatedListenerProcessingMode.PARTITION_ORDERED`: In this mode, messages are processed sequentially per partition while allowing concurrent execution across multiple partitions. +
-The default processing mode for the isolated listener is `PARTITION_ORDERED` to ensure a balance between throughput and consistency while preserving the order of messages within each partition.
-
-** `IsolatedListenerProcessingMode.SEQUENTIAL`: In this mode, messages are processed sequentially without any concurrency. this mode is used when the order of processing is critical and must be preserved across all partitions. +
-The `SEQUENTIAL` processing mode is not recommended for high-throughput scenarios due to its sequential nature, which can become a bottleneck. it is recommended to use this mode only when the strict ordering of message processing is a hard requirement and the expected message volume is low to moderate.
+NOTE: When `groupType = GroupType.CONSUMER`, the effective parallelism of any scope is still bounded by the partition count of the consumed topics. Choose `groupType = GroupType.SHARE` when you need to scale processing beyond the number of partitions.
 
 [[configuration_properties_stacksaga_kafka_worker]]
 == Configuration Properties Of `stacksaga-kafka-worker`
@@ -96,65 +95,60 @@ The `SEQUENTIAL` processing mode is not recommended for high-throughput scenario
 | Default Value
 | Description
 
-| `stacksaga.kafka.worker.auto-create-topics`
-| `boolean`
-| `true`
-| Whether the worker should automatically create the necessary Kafka topics (the topics that configured via `SagaEndpoint`s) if they do not exist.
+| `stacksaga.kafka.worker.global-endpoint-topic-listener.group-type`
+| `GroupType`
+| `SHARE`
+| The Kafka group protocol used by the global endpoint listener container that backs all `SHARED_GLOBAL` endpoints. `SHARE` uses the Kafka 4 share-group protocol (KIP-932, queue-style consumption); `CONSUMER` uses the classic consumer-group protocol. See xref:#worker_group_type[].
 
-| `stacksaga.kafka.worker.shared-topic-listener.processing-mode`
-| `SharedListenerProcessingMode`
-| `PARTITION_ORDERED`
-| The processing mode for the shared endpoint message listener. Default is `PARTITION_ORDERED`, which ensures that messages from the same partition of the same topic are processed in order.
-
-|`stacksaga.kafka.worker.shared-topic-listener.concurrency`
+| `stacksaga.kafka.worker.global-endpoint-topic-listener.concurrency`
 | `int`
-| `Runtime.getRuntime().availableProcessors() * 3`
-| The concurrency level for the shared endpoint message listener when the processing mode is set to `CONCURRENT`. This defines how many messages can be processed in parallel.
+| `20`
+| The concurrency level of the global endpoint listener container. With `group-type: SHARE`, this can be set to any desired value because share groups are not limited by the partition count. With `group-type: CONSUMER`, it should not exceed the total number of partitions of the endpoint topics bound to the global container.
 
-4+| Retry Configurations for Non-Reactive Endpoints : *Primary execution*
+4+| Retry Configurations for Non-Reactive Endpoints : *Primary execution* (immediate, in-process retries)
 
 | `stacksaga.kafka.worker.retry.primary.max-attempts`
 | `int`
-| `3`
-| The maximum number of retry attempts.
+| `5`
+| The maximum number of attempts (the initial attempt plus retries).
 
 | `stacksaga.kafka.worker.retry.primary.initial-interval`
 | `Duration`
 | `1s`
-| The initial interval between retry attempts.
+| The interval before the first retry.
 
 | `stacksaga.kafka.worker.retry.primary.max-interval`
 | `Duration`
-| `1s`
+| `10s`
 | The maximum interval between retry attempts.
 
 | `stacksaga.kafka.worker.retry.primary.multiplier`
 | `double`
 | `2.0`
-| The multiplier for the retry interval. For example, with an initial interval of 1 second and a multiplier of 2.0, the retry intervals would be 1s, 2s, 4s, etc., up to the maximum interval.
+| The multiplier applied to the retry interval on each attempt (exponential backoff). For example, with an initial interval of 1s and a multiplier of 2.0, the intervals grow 1s, 2s, 4s, … up to the maximum interval.
 
-4+| Retry Configurations for Non-Reactive Endpoints: *Revert execution*
+4+| Retry Configurations for Non-Reactive Endpoints: *Revert execution* (immediate, in-process retries)
 
 | `stacksaga.kafka.worker.retry.revert.max-attempts`
 | `int`
-| `3`
-| The maximum number of retry attempts.
+| `5`
+| The maximum number of attempts (the initial attempt plus retries).
 
 | `stacksaga.kafka.worker.retry.revert.initial-interval`
 | `Duration`
 | `1s`
-| The initial interval between retry attempts.
+| The interval before the first retry.
 
 | `stacksaga.kafka.worker.retry.revert.max-interval`
 | `Duration`
-| `1s`
+| `10s`
 | The maximum interval between retry attempts.
 
 | `stacksaga.kafka.worker.retry.revert.multiplier`
 | `double`
 | `2.0`
-| The multiplier for the retry interval. For example, with an initial interval of 1 second and a multiplier of 2.0, the retry intervals would be 1s, 2s, 4s, etc., up to the maximum interval.
-
+| The multiplier applied to the retry interval on each attempt (exponential backoff). For example, with an initial interval of 1s and a multiplier of 2.0, the intervals grow 1s, 2s, 4s, … up to the maximum interval.
 
 |===
 
+NOTE: These `retry.*` properties tune the *immediate, in-process* retries of non-reactive endpoints (the Spring `RetryTemplate` behind `JustRetryableExecutorException`). The *deferred, scheduled* retries triggered by `RetryableExecutorException` are configured separately through `stacksaga-database-support`.

--- a/docs/modules/implementations/pages/stacksaga-kafka-implementation/worker/worker-endpoints.adoc
+++ b/docs/modules/implementations/pages/stacksaga-kafka-implementation/worker/worker-endpoints.adoc
@@ -2,7 +2,7 @@
 :keywords: stacksaga-kafka-worker, QueryEndpoint, CommandEndpoint, NonRetryableExecutorException, RetryableExecutorException, JustRetryableExecutorException, SagaEndpoint, scheduler, RetryTemplate
 = stacksaga-kafka-worker — Endpoints
 
-*Stacksaga-kafka-worker* is the module that provides the functionalities for the worker services to execute the commands that are sent by the orchestrator via the regular topics. it is responsible for consuming the command messages from the regular topics, executing the business logic, and sending the response messages back to the orchestrator via the `response topics` (shared root topic or domain-root topic based on the listener scope configuration).
+*Stacksaga-kafka-worker* is the module that provides the functionalities for the worker services to execute the commands that are sent by the orchestrator via the regular topics. it is responsible for consuming the command messages from the regular topics, executing the business logic, and sending the response messages back to the orchestrator via the per-domain reply topic managed by the orchestrator.
 
 In high-level, The following duties are done by the `stacksaga-kafka-worker` module.
 
@@ -135,9 +135,10 @@ Non-reactive query endpoints are the traditional and blocking way of implementin
 ----
 //<2>
 @SagaEndpoint(
-        //the real topic name will be saga.do.user-service.validate-user
+        //the real topic name will be saga.do.user-service.get-user
         topicNameSuffix = "user-service.get-user", //<3>
-        listenerScope = ListenerScope.SHARED //<4>
+        listenerScope = WorkerListenerScope.SHARED_GLOBAL, //<4>
+        groupType = GroupType.SHARE
 )
 public class UserValidateEndpoint extends QueryEndpoint { //<1>
 
@@ -184,7 +185,10 @@ NOTE: The example has been simplified to focus on the main points. make sure ref
 <1> Create a custom query endpoint class by extending the `QueryEndpoint` class.
 <2> Annotate the custom query endpoint class with `@SagaEndpoint` annotation. it primarily marks the class as a spring bean.
 <3> *topicNameSuffix*: provide the suffix of the topic name for this endpoint. the framework will create the real topic name by concatenating the provided suffix as  `saga.do.user-service.get-user`. the prefix `saga.do` is added by the framework to indicate that this topic is used for the primary execution. this is the topic the `EventManager` will send the command messages to trigger the execution of this endpoint.
-<4> *listenerScope*: Provide the listener scope for the endpoint. it can be either `ListenerScope.SHARED` or `ListenerScope.ISOLATED`. see xref:stacksaga-kafka-implementation/worker/worker-configuration.adoc#topic_model_stacksaga_kafka_worker[]
+<4> *listenerScope* and *groupType*: Configure how this endpoint's topic is consumed. +
+*`listenerScope`* selects the listener-container allocation — `WorkerListenerScope.SHARED_GLOBAL` (pool into the single global container, the default choice), `WorkerListenerScope.SHARED_GROUP` (share a container with endpoints of the same `containerId`), or `WorkerListenerScope.ISOLATED` (a dedicated container). +
+*`groupType`* selects the Kafka group protocol — `GroupType.CONSUMER` (classic consumer group) or `GroupType.SHARE` (Kafka 4 share group / KIP-932, queue-style consumption not capped by partition count). +
+See xref:stacksaga-kafka-implementation/worker/worker-configuration.adoc#topic_model_stacksaga_kafka_worker[].
 
 <5> Override the `doProcess()` method to implement the business logic for executing the query. this method is invoked by the framework when a message is received in the respective topic. you can use the provided `ConsumerRecord` to access the message key, payload, and other metadata withing the method scope.
 
@@ -226,9 +230,10 @@ IMPORTANT: Make sure not to manage the exception related metadata withing your e
 ----
 @Slf4j
 @SagaEndpoint(
-        //the real topic name will be saga.do.user-service.validate-user
+        //the real topic name will be saga.do.user-service.get-user
         topicNameSuffix = "user-service.get-user",
-        listenerScope = ListenerScope.SHARED
+        listenerScope = WorkerListenerScope.SHARED_GLOBAL,
+        groupType = GroupType.SHARE
 )
 public class ReactiveUserValidateEndpoint extends ReactiveQueryEndpoint {//<1>
 
@@ -303,7 +308,8 @@ Non-reactive command endpoints are the traditional and blocking way of implement
 @Slf4j
 @SagaEndpoint(
         topicNameSuffix = "payment.service.make-payment",
-        listenerScope = ListenerScope.SHARED
+        listenerScope = WorkerListenerScope.SHARED_GLOBAL,
+        groupType = GroupType.SHARE
 )
 class MakePaymentEndpoint extends CommandEndpoint { //<1>
 
@@ -371,7 +377,8 @@ NOTE: Immediate retry with `RetryTemplate` is supported for `doProcess()` method
 @Slf4j
 @SagaEndpoint(
         topicNameSuffix = "payment.service.make-payment",
-        listenerScope = ListenerScope.SHARED
+        listenerScope = WorkerListenerScope.SHARED_GLOBAL,
+        groupType = GroupType.SHARE
 )
 public class MakePaymentEndpoint extends CommandEndpoint {
 
@@ -416,9 +423,11 @@ public class MakePaymentEndpoint extends CommandEndpoint {
 This example shows how to implement immediate retrying in the `MakePaymentEndpoint` command endpoint by using the `JustRetryableExecutorException`. in this example, if the `makePayment()` method throws a retryable exception, it checks the retry count from the `RetryContext` that is provided in the payload of the `ConsumerRecord`. although it has been wrapped with `Optional` you can safely access it because the retry context is always present if the executor is a non-reactive one. if the retry count has reached the threshold (in this example, it is 3), it throws a `NonRetryableExecutorException` to stop further immediate retries and indicate to the framework to schedule the retry based on the retry configurations. if the retry count has not reached the threshold, it throws a `JustRetryableExecutorException` with a message indicating to the framework to invoke an immediate retry. if the immediate retry is successful, it will avoid the delay that is caused by scheduling, and also it will avoid sending redundant messages to the orchestrator for each retry attempt.
 
 [[configure_custom_scheduler_for_non_reactive_endpoints]]
-==== Configure Custom `AbstractSagaEndpointSchedulerProvider` for Non-Reactive Endpoints
+==== Schedulers for Non-Reactive Endpoints
 
-Due to the fact that StackSaga works in non-blocking and reactive under the hood, If the endpoint is one of *non-reactive*, it should be configured the `Scheduler` for executing the blocking code in a non-blocking way. the framework provides a default shared Scheduler for both primary execution and revert execution of the non-reactive endpoints, but you can configure a custom `Scheduler` for your endpoints by creating a custom `AbstractSagaEndpointSchedulerProvider` and configuring it in the endpoint. because sometimes the default shared `Scheduler` may not be suitable for your use case, for instance, if you want to have a dedicated `Scheduler` for each endpoint or if you want to configure the `Scheduler` with specific configurations.
+Non-reactive (blocking) endpoint methods must not run directly on the Kafka listener threads, so the framework executes their blocking code on a Reactor `Scheduler`.
+Two application-wide bounded-elastic schedulers are provided by default — one for primary execution (`doProcess()`) and one for revert execution (`undoProcess()`) — and are shared by all non-reactive endpoints in the application.
+You can override these application-wide defaults with your own beans (see xref:#override_default_scheduler_configurations[]).
 
 The default shared `Scheduler` that is provided by the framework is a `boundedElastic` Scheduler with the fallowing configurations:
 
@@ -480,35 +489,7 @@ public class EndpointSchedulerConfig {
 }
 ----
 
-==== Create a Custom `AbstractSagaEndpointSchedulerProvider` for an Endpoint
-
-Here is an example of how to create a custom `AbstractSagaEndpointSchedulerProvider` and configure it in the endpoint.
-
-[source,java]
-----
-@Component
-public class MakePaymentExecutionSchedulerProvider extends AbstractSagaEndpointSchedulerProvider {
-    @Override
-    protected Scheduler scheduler() {
-        return Schedulers.newBoundedElastic(20, Integer.MAX_VALUE, "demo-name");
-    }
-}
-
-
-@Slf4j
-@SagaEndpoint(
-        listenerScope = ListenerScope.SHARED,
-        primaryExecutionSchedulerProvider = MakePaymentExecutionSchedulerProvider.class,
-        revertExecutionSchedulerProvider = MakePaymentExecutionSchedulerProvider.class
-)
-public class MakePaymentEndpoint extends CommandEndpoint {
-    //...
-}
-----
-
-IMPORTANT: the `scheduler()` method is invoked only once when the application starts and the returned the `Scheduler` and then framework will cache it for the future use.
-
-In this example, we created a custom `MakePaymentExecutionSchedulerProvider` that extends the `AbstractSagaEndpointSchedulerProvider` and overrides the `scheduler()` method to provide a custom `Scheduler` configuration. then we configured the custom `SchedulerProvider` in the `ReactiveMakePaymentEndpoint` for both primary execution and revert execution by using the `primaryExecutionSchedulerProvider` and `revertExecutionSchedulerProvider` attributes of the `@SagaEndpoint` annotation. you can configure different `SchedulerProvider` for primary execution and revert execution if you want to have different configurations for each execution as well.
+IMPORTANT: The `scheduler()` method is invoked only once when the application starts; the returned `Scheduler` is then cached by the framework and reused for all subsequent executions.
 
 [[configure_retry_template_for_non_reactive_endpoints]]
 ==== Configure `RetryTemplate` for Non-Reactive Endpoints
@@ -537,16 +518,21 @@ After creating the custom `RetryTemplateProvider`, you can configure it into the
 @Slf4j
 @SagaEndpoint(
         topicNameSuffix = "payment.service.make-payment",
-        listenerScope = ListenerScope.SHARED,
-        primaryExecutionRetryTemplate = MakePaymentRetryTemplateProvider.class, //<1>
-        revertExecutionRetryTemplate = MakePaymentRetryTemplateProvider.class //<2>
+        listenerScope = WorkerListenerScope.SHARED_GLOBAL,
+        groupType = GroupType.SHARE,
+        primaryExecutionRetryTemplate = "makePaymentRetryTemplateProvider", //<1>
+        revertExecutionRetryTemplate = "makePaymentRetryTemplateProvider" //<2>
 )
 public class MakePaymentEndpoint extends CommandEndpoint {
     //...
 }
 ----
 
-In this example, the `MakePaymentRetryTemplateProvider` is configured for both primary execution and revert execution by using the `primaryExecutionRetryTemplate` and `revertExecutionRetryTemplate` attributes of the `@SagaEndpoint` annotation. you can configure different `RetryTemplateProvider` for primary execution and revert execution if you want to have different retry behavior for each execution.
+In this example, the `MakePaymentRetryTemplateProvider` is configured for both primary execution and revert execution by using the `primaryExecutionRetryTemplate` and `revertExecutionRetryTemplate` attributes of the `@SagaEndpoint` annotation.
+Note that these attributes take the *Spring bean name* of the provider (a `String`), not the class — `makePaymentRetryTemplateProvider` is the default bean name generated for the `@Component`-annotated `MakePaymentRetryTemplateProvider` class.
+You can configure different providers for primary execution and revert execution if you want different retry behavior for each.
+
+NOTE: If these attributes are omitted, they default to the framework-provided shared providers `sharedDefaultPrimaryAbstractRetryTemplateProvider` and `sharedDefaultRevertAbstractRetryTemplateProvider`, whose behavior is tuned through the `stacksaga.kafka.worker.retry.primary.*` and `stacksaga.kafka.worker.retry.revert.*` properties (see xref:stacksaga-kafka-implementation/worker/worker-configuration.adoc#configuration_properties_stacksaga_kafka_worker[]).
 
 [[reactive-command-endpoint]]
 ==== Reactive (Non-Blocking) Command Endpoint
@@ -558,7 +544,8 @@ If you are in a reactive programming environment and want to implement the comma
 @Slf4j
 @SagaEndpoint( //<2>
         topicNameSuffix = "payment.service.make-payment",
-        listenerScope = ListenerScope.SHARED
+        listenerScope = WorkerListenerScope.SHARED_GLOBAL,
+        groupType = GroupType.SHARE
 )
 class ReactiveMakePaymentEndpoint extends ReactiveCommandEndpoint { //<1>
 
@@ -568,7 +555,7 @@ class ReactiveMakePaymentEndpoint extends ReactiveCommandEndpoint { //<1>
     }
 
     @Override
-    public Mono<Void> undoProcess(ReceiverRecord<String, SagaPayload> consumerRecord) {
+    public Mono<Void> undoProcess(ConsumerRecord<String, SagaPayload> consumerRecord) {
         log.info("Message Key (Transaction Id): {}", consumerRecord.key());
         log.info("IdempotencyKey: {}", consumerRecord.value().getIdempotencyKey());
         final JsonNode lastDomainEntityState = consumerRecord.value().getDomainEntityState();
@@ -637,49 +624,29 @@ Decimal values (e.g., `1.1`) are reserved for the upcoming sub-execution feature
 See full specification in xref:stacksaga-kafka-implementation/orchestrator/topics-event-manager.adoc#topic_name_specification[Topic Name Specification] and xref:stacksaga-kafka-implementation/orchestrator/topics-event-manager.adoc#topic_key_specification[Topic Key Specification].
 
 . `listenerScope`
-- Provide the listener scope for the endpoint. `listenerScope` defines how the message listeners are created and managed for the endpoint. it can be either `ListenerScope.SHARED` or `ListenerScope.ISOLATED`. if it is set to `ListenerScope.SHARED`, the framework binds the respective topic to the default shared message listener container. if it is set to `ListenerScope.ISOLATED`, the framework creates a dedicated message listener container for the respective topic. if you want to have an isolated listener for a specific endpoint, you can set the `listenerScope` to `ListenerScope.ISOLATED` for that endpoint. this allows you to have better control over the message consumption and processing for that specific endpoint without affecting other endpoints that share the same listener. listenerScope tuning is one of the most important configurations that should be highly considered. read the xref:#[ListenerScope tuning] section in the best practices chapter to understand how to choose the appropriate listener scope for your endpoints based on your use case and requirements.
+- Selects the listener-container allocation for the endpoint.
+`WorkerListenerScope.SHARED_GLOBAL` pools the endpoint into the single global container shared by all default endpoints (the default choice); `WorkerListenerScope.SHARED_GROUP` shares a container with other endpoints that declare the same `containerId`; `WorkerListenerScope.ISOLATED` gives the endpoint a dedicated container.
+listenerScope tuning is one of the most important configurations and should be considered carefully. see xref:stacksaga-kafka-implementation/worker/worker-configuration.adoc#topic_model_stacksaga_kafka_worker[].
 
-. `processingMode`
-- Provide the processing mode if the `listenerScope` is set to `ListenerScope.ISOLATED`. see xref:stacksaga-kafka-implementation/worker/worker-configuration.adoc#topic_model_stacksaga_kafka_worker[] for more details.
+. `groupType`
+- Selects the Kafka group protocol for the endpoint's container.
+`GroupType.CONSUMER` uses the classic consumer-group protocol (a `ConcurrentMessageListenerContainer`); `GroupType.SHARE` uses the Kafka 4 share-group protocol (KIP-932, a `ShareKafkaMessageListenerContainer`), whose parallelism is not capped by the partition count.
+Every endpoint sharing a container (all `SHARED_GLOBAL` endpoints, or all members of a `SHARED_GROUP`) must declare the *same* `groupType`; a mismatch fails fast at startup.
+`GroupType.SHARE` requires a Kafka 4.x broker with share groups enabled.
 
-. `primaryExecutionConcurrency`
-- Specifies the concurrency level used for primary record processing (for `doProcess()`) when `processingMode` is configured as `ProcessingMode.CONCURRENT`.
-Multiple records may be processed concurrently using the configured number of worker threads. +
-The value may be provided either as a numeric literal or as a Spring property placeholder. +
-For example: +
-`primaryExecutionConcurrency = "10"` +
-`primaryExecutionConcurrency = "${saga.sample1.primary.concurrency}"`
-+
-When a property placeholder is used, the value is resolved from the application configuration.
-`saga.sample1.primary.concurrency=10`
-+
-`Default: Runtime.getRuntime().availableProcessors() * 2`
+. `containerId`
+- Only used when `listenerScope = WorkerListenerScope.SHARED_GROUP`.
+It is the group key that binds endpoints together into a single shared container — endpoints declaring the same `containerId` share one container. Ignored for the other scopes.
 
-. `revertExecutionConcurrency`
-- Specifies the concurrency level used for compensation record processing (for `undoProcess()`) when `processingMode` is configured as `ProcessingMode.CONCURRENT`.
-Multiple records may be processed concurrently using the configured number of worker threads. +
-The value may be provided either as a numeric literal or as a Spring property placeholder. +
-For example: +
-`revertExecutionConcurrency = "5"` +
-`revertExecutionConcurrency = "${saga.sample1.revert.concurrency}"`
-+
-When a property placeholder is used, the value is resolved from the application configuration.
-`saga.sample1.revert.concurrency=5`
-+
-Default: `Runtime.getRuntime().availableProcessors()`
-+
-This is not applicable for the `QueryEndpoint` because it does not have compensation processing, so the `revertExecutionConcurrency` will be ignored if it is provided in the `@SagaEndpoint` annotation of a `QueryEndpoint`.
+. `concurrency`
+- The concurrency level of the endpoint's listener container (default `1`).
+For an `ISOLATED` endpoint it sets that dedicated container's concurrency. For a `SHARED_GROUP` endpoint the container adopts the *maximum* `concurrency` declared across all members of the group. (For `SHARED_GLOBAL`, the global container's concurrency comes from the `stacksaga.kafka.worker.global-endpoint-topic-listener.concurrency` property instead.)
+With `GroupType.CONSUMER`, effective parallelism is still bounded by the partition count; with `GroupType.SHARE` it is not.
 
 . `primaryExecutionRetryTemplate`
-- Specifies the `RetryTemplateProvider` class to be used for primary execution retries for non-reactive `CommandEndpoint` and `QueryEndpoint`'s `doProcess()` method. see xref:#configure_retry_template_for_non_reactive_endpoints[] for more details.
+- The *Spring bean name* (a `String`) of the `AbstractRetryTemplateProvider` used for immediate, in-process retries of the primary execution (`doProcess()`) of non-reactive `CommandEndpoint` and `QueryEndpoint`.
+Defaults to `"sharedDefaultPrimaryAbstractRetryTemplateProvider"`. see xref:#configure_retry_template_for_non_reactive_endpoints[].
 
 . `revertExecutionRetryTemplate`
-- Specifies the `RetryTemplateProvider` class to be used for compensation execution retries for non-reactive `CommandEndpoint`'s `undoProcess()` method. see xref:#configure_retry_template_for_non_reactive_endpoints[] for more details.
-
-. `primaryExecutionSchedulerProvider`
-- Only applicable with primary executions (`CommandEndpoint.doProcess(ConsumerRecord)`, `QueryEndpoint.doProcess(ConsumerRecord)`).
-Provides a custom `AbstractPrimaryExecutionSchedulerProvider` for controlling the scheduler on which the primary execution processing occurs.
-#This is important for isolating blocking operations from the Kafka consumer thread to prevent performance degradation and ensure responsiveness#.
-By default, the framework will use a *bounded elastic scheduler* suitable for blocking workloads via `DefaultSchedulerConfig`, but you can provide your own implementation to customize pool size, naming, and other characteristics.
-It is not recommended to provide separate schedulers for each unless if it is necessary for your use case, as it may lead to resource contention and inefficient thread usage.
-In most cases, a shared scheduler for all endpoints is sufficient and more efficient. but using shared default scheduler can lead to starvation of tasks. see the xref:#configure_custom_scheduler_for_non_reactive_endpoints[] section to see how it can be configured a custom scheduler or see the xref:#override_default_scheduler_configurations[] section to see how to override the existing default shared scheduler configurations.
+- The *Spring bean name* (a `String`) of the `AbstractRetryTemplateProvider` used for immediate, in-process retries of the compensation execution (`undoProcess()`) of a non-reactive `CommandEndpoint`.
+Defaults to `"sharedDefaultRevertAbstractRetryTemplateProvider"`. see xref:#configure_retry_template_for_non_reactive_endpoints[].


### PR DESCRIPTION
Introduce Kafka 4 (KIP-932) share-group support and richer listener/container scopes across orchestrator and worker docs. Adds groupType (CONSUMER|SHARE), new OrchestratorListenerScope/WorkerListenerScope values (SHARED_GLOBAL, SHARED_GROUP, ISOLATED), updated properties (global-callback-listener.*, global-endpoint-topic-listener.*) and concurrency defaults. Clarifies consumption models, threading/ordering guidance, retry defaults and scheduler behavior, and updates examples to show share-group usage. Edited: index.adoc, properties.adoc, topics-event-manager.adoc, stacksaga-kafka-architecture.adoc, worker-configuration.adoc, worker-endpoints.adoc.